### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkDICOMOrientImageFilter.h
+++ b/include/itkDICOMOrientImageFilter.h
@@ -66,7 +66,7 @@ class ITK_TEMPLATE_EXPORT DICOMOrientImageFilter
   : public ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DICOMOrientImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(DICOMOrientImageFilter);
 
   /** Standard class type aliases. */
   using Self = DICOMOrientImageFilter;

--- a/include/itkHessianImageFilter.h
+++ b/include/itkHessianImageFilter.h
@@ -46,7 +46,7 @@ template <typename TInputImage,
 class HessianImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(HessianImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(HessianImageFilter);
 
   /** Standard type alias */
   using Self = HessianImageFilter;

--- a/include/itkNPasteImageFilter.h
+++ b/include/itkNPasteImageFilter.h
@@ -60,7 +60,7 @@ template <typename TInputImage, typename TSourceImage = TInputImage, typename TO
 class ITK_TEMPLATE_EXPORT NPasteImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(NPasteImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(NPasteImageFilter);
 
   /** Standard class type aliases. */
   using Self = NPasteImageFilter;

--- a/include/itkObjectnessMeasureImageFilter.h
+++ b/include/itkObjectnessMeasureImageFilter.h
@@ -74,7 +74,7 @@ template <typename TInputImage, typename TOutputImage>
 class ObjectnessMeasureImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ObjectnessMeasureImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ObjectnessMeasureImageFilter);
 
   /** Standard class type alias. */
   using Self = ObjectnessMeasureImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.