### PR TITLE
STYLE: Match clang-format style for ITK

### DIFF
--- a/include/itkDICOMOrientImageFilter.h
+++ b/include/itkDICOMOrientImageFilter.h
@@ -62,8 +62,7 @@ namespace itk
  * \ingroup SimpleITKFilters
  */
 template <typename TInputImage>
-class ITK_TEMPLATE_EXPORT DICOMOrientImageFilter
-  : public ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT DICOMOrientImageFilter : public ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DICOMOrientImageFilter);
@@ -140,7 +139,7 @@ public:
   void
   GenerateOutputInformation() override;
 
-  static_assert(ImageDimension == 3, "Only 3 dimensional images are support!" );
+  static_assert(ImageDimension == 3, "Only 3 dimensional images are support!");
 
 protected:
   DICOMOrientImageFilter();
@@ -154,7 +153,7 @@ protected:
 
   /*** Member functions used by GenerateData: */
   void
-  DeterminePermutationsAndFlips(DICOMOrientation desired,  DICOMOrientation given);
+  DeterminePermutationsAndFlips(DICOMOrientation desired, DICOMOrientation given);
 
   /** Returns true if a permute is required. Returns false otherwise. */
   bool

--- a/include/itkDICOMOrientImageFilter.hxx
+++ b/include/itkDICOMOrientImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 
 template <typename TInputImage>
 DICOMOrientImageFilter<TInputImage>::DICOMOrientImageFilter()
-  : m_FlipAxes{false}
+  : m_FlipAxes{ false }
 {
   for (unsigned int dimension = 0; dimension < ImageDimension; ++dimension)
   {
@@ -159,7 +159,7 @@ DICOMOrientImageFilter<TInputImage>::SetDesiredCoordinateOrientation(const std::
 {
   DICOMOrientation o(desired);
 
-  if ( OrientationEnum(o) == OrientationEnum::INVALID)
+  if (OrientationEnum(o) == OrientationEnum::INVALID)
   {
     itkWarningMacro("Invalid desired coordinate direction string: \"" << desired << "\"!");
   }
@@ -301,7 +301,7 @@ DICOMOrientImageFilter<TInputImage>::VerifyPreconditions() ITKv5_CONST
 
   if (this->m_DesiredCoordinateOrientation == OrientationEnum::INVALID)
   {
-    itkExceptionMacro(<<"DesiredCoordinateOrientation is 'INVALID'.")
+    itkExceptionMacro(<< "DesiredCoordinateOrientation is 'INVALID'.");
   }
 }
 

--- a/include/itkDICOMOrientation.h
+++ b/include/itkDICOMOrientation.h
@@ -216,7 +216,7 @@ public:
 
 
   friend SimpleITKFilters_EXPORT std::ostream &
-  operator<<(std::ostream & out, OrientationEnum value);
+                                 operator<<(std::ostream & out, OrientationEnum value);
 
 
 private:

--- a/include/itkMaskedAssignImageFilter.h
+++ b/include/itkMaskedAssignImageFilter.h
@@ -56,47 +56,55 @@ namespace itk
  * \ingroup SimpleITKFilters
  *
  */
-    template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
-    class MaskedAssignImageFilter : public TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>
+template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
+class MaskedAssignImageFilter : public TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>
 
-    {
-    public:
-        ITK_DISALLOW_COPY_AND_MOVE(MaskedAssignImageFilter);
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(MaskedAssignImageFilter);
 
-        /** Standard class type aliases. */
-        using Self = MaskedAssignImageFilter;
-        using Superclass = TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>;
+  /** Standard class type aliases. */
+  using Self = MaskedAssignImageFilter;
+  using Superclass = TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>;
 
-        using Pointer = SmartPointer<Self>;
-        using ConstPointer = SmartPointer<const Self>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
-        /** Method for creation through the object factory. */
-        itkNewMacro(Self);
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
 
-        /** Runtime information support. */
-        itkTypeMacro(MaskedAssignImageFilter, TernaryGeneratorImageFilter);
+  /** Runtime information support. */
+  itkTypeMacro(MaskedAssignImageFilter, TernaryGeneratorImageFilter);
 
-        /** Typedefs **/
-        using InputImageType = TInputImage;
-        using MaskImageType = TMaskImage;
-        using AssignImageType = TOutputImage;
-        using OutputImageType = TOutputImage;
+  /** Typedefs **/
+  using InputImageType = TInputImage;
+  using MaskImageType = TMaskImage;
+  using AssignImageType = TOutputImage;
+  using OutputImageType = TOutputImage;
 
-        using OutputPixelType = typename OutputImageType::PixelType;
+  using OutputPixelType = typename OutputImageType::PixelType;
 
-        itkSetInputMacro(MaskImage, MaskImageType);
-        itkGetInputMacro(MaskImage, MaskImageType);
+  itkSetInputMacro(MaskImage, MaskImageType);
+  itkGetInputMacro(MaskImage, MaskImageType);
 
-        itkSetInputMacro(AssignImage, AssignImageType);
-        itkGetInputMacro(AssignImage, AssignImageType);
+  itkSetInputMacro(AssignImage, AssignImageType);
+  itkGetInputMacro(AssignImage, AssignImageType);
 
-        virtual void SetAssignConstant( const OutputPixelType &v) { this->SetConstant3(v); }
-        virtual OutputPixelType GetAssignConstant( ) const {return this->GetConstant3(); }
+  virtual void
+  SetAssignConstant(const OutputPixelType & v)
+  {
+    this->SetConstant3(v);
+  }
+  virtual OutputPixelType
+  GetAssignConstant() const
+  {
+    return this->GetConstant3();
+  }
 
-    protected:
-        MaskedAssignImageFilter();
-        ~MaskedAssignImageFilter() override = default;
-    };
+protected:
+  MaskedAssignImageFilter();
+  ~MaskedAssignImageFilter() override = default;
+};
 } // end namespace itk
 
 #endif

--- a/include/itkMaskedAssignImageFilter.hxx
+++ b/include/itkMaskedAssignImageFilter.hxx
@@ -20,25 +20,29 @@
 
 #include "itkMaskedAssignImageFilter.h"
 
-namespace itk {
-    template<typename TInputImage, typename TMaskImage, typename TOutputImage>
-    MaskedAssignImageFilter<TInputImage, TMaskImage, TOutputImage>::MaskedAssignImageFilter() {
-        this->SetPrimaryInputName("InputImage");
-        this->AddRequiredInputName("MaskImage", 1);
-        this->AddRequiredInputName("AssignImage", 2);
+namespace itk
+{
+template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+MaskedAssignImageFilter<TInputImage, TMaskImage, TOutputImage>::MaskedAssignImageFilter()
+{
+  this->SetPrimaryInputName("InputImage");
+  this->AddRequiredInputName("MaskImage", 1);
+  this->AddRequiredInputName("AssignImage", 2);
 
-        auto func = [](const typename InputImageType::PixelType &input,
-                       const typename MaskImageType::PixelType &mask,
-                       const typename AssignImageType::PixelType &assign) ->
-                OutputPixelType {
-            if (mask != NumericTraits<typename MaskImageType::PixelType>::Zero) {
-                return assign;
-            } else {
-                return static_cast<OutputPixelType>(input);
-            }
-        };
-        this->SetFunctor(func);
+  auto func = [](const typename InputImageType::PixelType &  input,
+                 const typename MaskImageType::PixelType &   mask,
+                 const typename AssignImageType::PixelType & assign) -> OutputPixelType {
+    if (mask != NumericTraits<typename MaskImageType::PixelType>::Zero)
+    {
+      return assign;
     }
+    else
+    {
+      return static_cast<OutputPixelType>(input);
+    }
+  };
+  this->SetFunctor(func);
+}
 
 } // end namespace itk
 

--- a/include/itkNPasteImageFilter.h
+++ b/include/itkNPasteImageFilter.h
@@ -40,8 +40,8 @@ namespace itk
  * repositioned to DestinationIndex, then the output will just be
  * a copy of the input.
  *
- * This filter supports running "InPlace" to efficiently reuses the destination image buffer for the output, removing the
- * need to copy the destination pixels to the output.
+ * This filter supports running "InPlace" to efficiently reuses the destination image buffer for the output, removing
+ * the need to copy the destination pixels to the output.
  *
  * When the source image is a lower dimension than the destination image then the DestinationSkipAxes parameter
  * specifies which axes in the destination image are set to 1 when copying the region or filling with a constant.

--- a/include/itkNPasteImageFilter.hxx
+++ b/include/itkNPasteImageFilter.hxx
@@ -89,7 +89,7 @@ NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions(
 
   if (sourceInput == nullptr && constantInput == nullptr)
   {
-    itkExceptionMacro("The Source or the Constant input are required.")
+    itkExceptionMacro("The Source or the Constant input are required.");
   }
 
 
@@ -285,7 +285,7 @@ NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::GetPresumedDestinati
 
   if (numberSkippedAxis != (InputImageDimension - SourceImageDimension))
   {
-    itkExceptionMacro("Number of skipped axis " << m_DestinationSkipAxes)
+    itkExceptionMacro("Number of skipped axis " << m_DestinationSkipAxes);
   }
 
   InputImageSizeType ret;

--- a/src/itkDICOMOrientation.cxx
+++ b/src/itkDICOMOrientation.cxx
@@ -55,12 +55,12 @@ const std::string &
 DICOMOrientation::GetAsString() const
 {
   const auto & codeToString = GetCodeToString();
-  auto iter = codeToString.find(m_Value);
+  auto         iter = codeToString.find(m_Value);
   if (iter != codeToString.end())
-    {
+  {
     return iter->second;
-    }
-  assert( codeToString.find(OrientationEnum::INVALID) != codeToString.end());
+  }
+  assert(codeToString.find(OrientationEnum::INVALID) != codeToString.end());
   return codeToString.find(OrientationEnum::INVALID)->second;
 }
 

--- a/test/itkMaskedAssignImageFilterGTest.cxx
+++ b/test/itkMaskedAssignImageFilterGTest.cxx
@@ -26,225 +26,230 @@
 
 namespace
 {
-    class MaskedAssignFixture : public ::testing::Test
+class MaskedAssignFixture : public ::testing::Test
+{
+public:
+  MaskedAssignFixture() = default;
+  ~MaskedAssignFixture() override = default;
+
+protected:
+  void
+  SetUp() override
+  {
+    RegisterRequiredFactories();
+  }
+
+  template <typename TImageType>
+  static std::string
+  MD5Hash(const TImageType * image)
+  {
+
+    using HashFilter = itk::Testing::HashImageFilter<TImageType>;
+    typename HashFilter::Pointer hasher = HashFilter::New();
+    hasher->SetInput(image);
+    hasher->InPlaceOff();
+    hasher->Update();
+    return hasher->GetHash();
+  }
+
+  template <typename TInputImage, typename TMaskImage = TInputImage>
+  struct FixtureUtilities
+  {
+    static const unsigned int Dimension = TInputImage::ImageDimension;
+
+    using PixelType = typename TInputImage::PixelType;
+    using OutputPixelType = PixelType;
+    using InputImageType = TInputImage;
+    using OutputImageType = TInputImage;
+    using RegionType = typename InputImageType::RegionType;
+    using SizeType = typename TInputImage::SizeType;
+    using IndexType = typename TInputImage::IndexType;
+
+
+    using MaskImageType = TMaskImage;
+    using MaskRegionType = typename MaskImageType::RegionType;
+    using MaskSizeType = typename MaskImageType::SizeType;
+    using MaskIndexType = typename MaskImageType::IndexType;
+
+    using FilterType = itk::MaskedAssignImageFilter<InputImageType, MaskImageType, OutputImageType>;
+
+    // Create a black image or empty
+    template <typename TImage>
+    static typename TImage::Pointer
+    CreateImageT(unsigned int size = 100)
     {
-    public:
-        MaskedAssignFixture() = default;
-        ~MaskedAssignFixture() override = default;
+      typename TImage::Pointer image = TImage::New();
 
-    protected:
-        void
-        SetUp() override
-        {
-            RegisterRequiredFactories();
-        }
+      typename TImage::SizeType imageSize;
+      imageSize.Fill(size);
+      image->SetRegions(typename TImage::RegionType(imageSize));
+      InitializeImage(image.GetPointer());
 
-        template <typename TImageType>
-        static std::string
-        MD5Hash(const TImageType * image)
-        {
+      return image;
+    }
 
-            using HashFilter = itk::Testing::HashImageFilter<TImageType>;
-            typename HashFilter::Pointer hasher = HashFilter::New();
-            hasher->SetInput(image);
-            hasher->InPlaceOff();
-            hasher->Update();
-            return hasher->GetHash();
-        }
-
-        template <typename TInputImage, typename TMaskImage = TInputImage>
-        struct FixtureUtilities
-        {
-            static const unsigned int Dimension = TInputImage::ImageDimension;
-
-            using PixelType = typename TInputImage::PixelType;
-            using OutputPixelType = PixelType;
-            using InputImageType = TInputImage;
-            using OutputImageType = TInputImage;
-            using RegionType = typename InputImageType::RegionType;
-            using SizeType = typename TInputImage::SizeType;
-            using IndexType = typename TInputImage::IndexType;
+    template <typename TPixelType, unsigned int D>
+    static void
+    InitializeImage(itk::Image<TPixelType, D> * image)
+    {
+      image->Allocate();
+      image->FillBuffer(itk::NumericTraits<TPixelType>::ZeroValue());
+    }
 
 
-            using MaskImageType = TMaskImage;
-            using MaskRegionType = typename MaskImageType::RegionType;
-            using MaskSizeType = typename MaskImageType::SizeType;
-            using MaskIndexType = typename MaskImageType::IndexType;
+    template <typename TPixelType, unsigned int D>
+    static void
+    InitializeImage(itk::VectorImage<TPixelType, D> * image)
+    {
+      constexpr unsigned int sz = 3;
+      image->SetNumberOfComponentsPerPixel(sz);
+      image->Allocate();
+      itk::VariableLengthVector<TPixelType> p{ sz };
+      p.Fill(itk::NumericTraits<TPixelType>::ZeroValue());
+      image->FillBuffer(p);
+    }
 
-            using FilterType = itk::MaskedAssignImageFilter<InputImageType, MaskImageType, OutputImageType>;
-
-            // Create a black image or empty
-            template <typename TImage>
-            static typename TImage::Pointer
-            CreateImageT(unsigned int size = 100)
-            {
-                typename TImage::Pointer image = TImage::New();
-
-                typename TImage::SizeType imageSize;
-                imageSize.Fill(size);
-                image->SetRegions(typename TImage::RegionType(imageSize));
-                InitializeImage(image.GetPointer());
-
-                return image;
-            }
-
-            template<typename TPixelType, unsigned int D>
-            static void InitializeImage(itk::Image<TPixelType, D> *image)
-            {
-                image->Allocate();
-                image->FillBuffer(itk::NumericTraits<TPixelType>::ZeroValue());
-            }
-
-
-            template<typename TPixelType, unsigned int D>
-            static void InitializeImage(itk::VectorImage<TPixelType, D> *image)
-            {
-                constexpr unsigned int sz = 3;
-                image->SetNumberOfComponentsPerPixel(sz);
-                image->Allocate();
-                itk::VariableLengthVector<TPixelType> p{sz};
-                p.Fill(itk::NumericTraits<TPixelType>::ZeroValue());
-                image->FillBuffer(p);
-            }
-
-            static constexpr auto CreateImage = CreateImageT<InputImageType>;
-            static constexpr auto CreateMaskImage = CreateImageT<MaskImageType>;
-        };
-    };
+    static constexpr auto CreateImage = CreateImageT<InputImageType>;
+    static constexpr auto CreateMaskImage = CreateImageT<MaskImageType>;
+  };
+};
 } // namespace
 
 
-TEST_F(MaskedAssignFixture, SetGetPrint) {
-    using Utils = FixtureUtilities<itk::Image<float, 3>>;
+TEST_F(MaskedAssignFixture, SetGetPrint)
+{
+  using Utils = FixtureUtilities<itk::Image<float, 3>>;
 
-    auto filter = Utils::FilterType::New();
+  auto filter = Utils::FilterType::New();
 
-    auto image = Utils::CreateImage(100);
+  auto image = Utils::CreateImage(100);
 
-    EXPECT_STREQ("MaskedAssignImageFilter", filter->GetNameOfClass());
+  EXPECT_STREQ("MaskedAssignImageFilter", filter->GetNameOfClass());
 
-    EXPECT_NO_THROW(filter->SetInput(image));
-    EXPECT_EQ(image, filter->GetInput());
-    EXPECT_ANY_THROW(filter->GetConstant1());
+  EXPECT_NO_THROW(filter->SetInput(image));
+  EXPECT_EQ(image, filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetConstant1());
 
-    image = Utils::CreateImage(100);
-    EXPECT_NO_THROW(filter->SetInput1(image));
-    EXPECT_EQ(image, filter->GetInput());
-    EXPECT_ANY_THROW(filter->GetConstant1());
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetInput1(image));
+  EXPECT_EQ(image, filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetConstant1());
 
-    EXPECT_NO_THROW(filter->SetConstant1(1));
-    EXPECT_ANY_THROW(filter->GetInput());
-    EXPECT_EQ(1, filter->GetConstant1());
-
-
-    image = Utils::CreateImage(100);
-    EXPECT_NO_THROW(filter->SetInput2(image));
-    EXPECT_EQ(image, filter->GetMaskImage());
-    EXPECT_ANY_THROW(filter->GetConstant2());
-
-    image = Utils::CreateImage(100);
-    EXPECT_NO_THROW(filter->SetMaskImage(image));
-    EXPECT_EQ(image, filter->GetMaskImage());
-    EXPECT_ANY_THROW(filter->GetConstant2());
-
-    EXPECT_NO_THROW(filter->SetConstant2(2));
-    EXPECT_ANY_THROW(filter->GetMaskImage());
-    EXPECT_EQ(2, filter->GetConstant2());
+  EXPECT_NO_THROW(filter->SetConstant1(1));
+  EXPECT_ANY_THROW(filter->GetInput());
+  EXPECT_EQ(1, filter->GetConstant1());
 
 
-    image = Utils::CreateImage(100);
-    EXPECT_NO_THROW(filter->SetInput3(image));
-    EXPECT_EQ(image, filter->GetAssignImage());
-    EXPECT_ANY_THROW(filter->GetConstant3());
-    EXPECT_ANY_THROW(filter->GetAssignConstant());
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetInput2(image));
+  EXPECT_EQ(image, filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetConstant2());
 
-    image = Utils::CreateImage(100);
-    EXPECT_NO_THROW(filter->SetAssignImage(image));
-    EXPECT_EQ(image, filter->GetAssignImage());
-    EXPECT_ANY_THROW(filter->GetConstant3());
-    EXPECT_ANY_THROW(filter->GetAssignConstant());
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetMaskImage(image));
+  EXPECT_EQ(image, filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetConstant2());
 
-    EXPECT_NO_THROW(filter->SetConstant3(3));
-    EXPECT_ANY_THROW(filter->GetMaskImage());
-    EXPECT_EQ(3, filter->GetConstant3());
+  EXPECT_NO_THROW(filter->SetConstant2(2));
+  EXPECT_ANY_THROW(filter->GetMaskImage());
+  EXPECT_EQ(2, filter->GetConstant2());
 
 
-    EXPECT_NO_THROW(filter->SetAssignConstant(4));
-    EXPECT_ANY_THROW(filter->GetMaskImage());
-    EXPECT_EQ(4, filter->GetConstant3());
-    EXPECT_EQ(4, filter->GetAssignConstant());
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetInput3(image));
+  EXPECT_EQ(image, filter->GetAssignImage());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+  EXPECT_ANY_THROW(filter->GetAssignConstant());
+
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetAssignImage(image));
+  EXPECT_EQ(image, filter->GetAssignImage());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+  EXPECT_ANY_THROW(filter->GetAssignConstant());
+
+  EXPECT_NO_THROW(filter->SetConstant3(3));
+  EXPECT_ANY_THROW(filter->GetMaskImage());
+  EXPECT_EQ(3, filter->GetConstant3());
+
+
+  EXPECT_NO_THROW(filter->SetAssignConstant(4));
+  EXPECT_ANY_THROW(filter->GetMaskImage());
+  EXPECT_EQ(4, filter->GetConstant3());
+  EXPECT_EQ(4, filter->GetAssignConstant());
 }
 
-TEST_F(MaskedAssignFixture, Test1) {
+TEST_F(MaskedAssignFixture, Test1)
+{
 
-    using Utils = FixtureUtilities<itk::Image<float, 3>, itk::Image<unsigned char, 3>>;
+  using Utils = FixtureUtilities<itk::Image<float, 3>, itk::Image<unsigned char, 3>>;
 
 
-    auto image = Utils::CreateImage(100);
-    image->FillBuffer(99);
+  auto image = Utils::CreateImage(100);
+  image->FillBuffer(99);
 
-    auto mask = Utils::CreateMaskImage(100);
-    mask->FillBuffer(0);
+  auto mask = Utils::CreateMaskImage(100);
+  mask->FillBuffer(0);
 
-    auto filter = Utils::FilterType::New();
+  auto filter = Utils::FilterType::New();
 
-    EXPECT_NO_THROW(filter->SetAssignConstant(5));
-    EXPECT_EQ(5, filter->GetAssignConstant());
+  EXPECT_NO_THROW(filter->SetAssignConstant(5));
+  EXPECT_EQ(5, filter->GetAssignConstant());
 
-    mask->SetPixel({ {0,0}}, 1);
+  mask->SetPixel({ { 0, 0 } }, 1);
 
-    mask->SetPixel({{20,21}}, 1);
+  mask->SetPixel({ { 20, 21 } }, 1);
 
-    filter->SetInput(image);
-    filter->SetMaskImage(mask);
+  filter->SetInput(image);
+  filter->SetMaskImage(mask);
 
-    filter->Update();
-    auto output = filter->GetOutput();
+  filter->Update();
+  auto output = filter->GetOutput();
 
-    EXPECT_EQ(5, output->GetPixel({{0,0}}));
-    EXPECT_EQ(99, output->GetPixel({{0,1}}));
+  EXPECT_EQ(5, output->GetPixel({ { 0, 0 } }));
+  EXPECT_EQ(99, output->GetPixel({ { 0, 1 } }));
 
-    EXPECT_EQ(99, output->GetPixel({{1,1}}));
+  EXPECT_EQ(99, output->GetPixel({ { 1, 1 } }));
 
-    EXPECT_EQ(5, output->GetPixel({{20,21}}));
+  EXPECT_EQ(5, output->GetPixel({ { 20, 21 } }));
 
-    EXPECT_EQ("b28618b5cccaa828028a29b44d88c728", MD5Hash(output));
+  EXPECT_EQ("b28618b5cccaa828028a29b44d88c728", MD5Hash(output));
 }
 
 
-TEST_F(MaskedAssignFixture, VectorTest2) {
+TEST_F(MaskedAssignFixture, VectorTest2)
+{
 
-    using Utils = FixtureUtilities<itk::VectorImage<unsigned char, 3>, itk::Image<unsigned char, 3>>;
+  using Utils = FixtureUtilities<itk::VectorImage<unsigned char, 3>, itk::Image<unsigned char, 3>>;
 
-    auto image = Utils::CreateImage(21);
-    Utils::PixelType p{image->GetNumberOfComponentsPerPixel()};
-    p.Fill( 12 );
-    image->FillBuffer( p );
+  auto             image = Utils::CreateImage(21);
+  Utils::PixelType p{ image->GetNumberOfComponentsPerPixel() };
+  p.Fill(12);
+  image->FillBuffer(p);
 
-    auto filter = Utils::FilterType::New();
+  auto filter = Utils::FilterType::New();
 
-    Utils::PixelType c{3};
-    c.Fill( 0 );
-    EXPECT_NO_THROW(filter->SetAssignConstant(c));
-    EXPECT_EQ(c, filter->GetAssignConstant());
-
-
-    auto mask = Utils::CreateMaskImage(21);
-    mask->FillBuffer(0);
-    mask->SetPixel({ {2,2}}, 1);
-
-    mask->SetPixel({{3,19}}, 1);
-
-    filter->SetInput(image);
-    filter->SetMaskImage(mask);
-
-    filter->Update();
-    auto output = filter->GetOutput();
-
-    EXPECT_EQ(p, output->GetPixel({{0,0}}));
-    EXPECT_EQ(c, output->GetPixel({{2,2}}));
-    EXPECT_EQ(c, output->GetPixel({{3,19}}));
+  Utils::PixelType c{ 3 };
+  c.Fill(0);
+  EXPECT_NO_THROW(filter->SetAssignConstant(c));
+  EXPECT_EQ(c, filter->GetAssignConstant());
 
 
-    EXPECT_EQ("f089464fcbec9429f409ee779788cca3", MD5Hash(output));
+  auto mask = Utils::CreateMaskImage(21);
+  mask->FillBuffer(0);
+  mask->SetPixel({ { 2, 2 } }, 1);
+
+  mask->SetPixel({ { 3, 19 } }, 1);
+
+  filter->SetInput(image);
+  filter->SetMaskImage(mask);
+
+  filter->Update();
+  auto output = filter->GetOutput();
+
+  EXPECT_EQ(p, output->GetPixel({ { 0, 0 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 2, 2 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 3, 19 } }));
+
+
+  EXPECT_EQ("f089464fcbec9429f409ee779788cca3", MD5Hash(output));
 }


### PR DESCRIPTION
When adding missing macro end-of-line semi-colons, the clang-format
corrections make the code more consistent to read.