### PR TITLE
COMP: Add missing ';' at end of macro

### DIFF
--- a/include/itkDICOMOrientImageFilter.hxx
+++ b/include/itkDICOMOrientImageFilter.hxx
@@ -301,7 +301,7 @@ DICOMOrientImageFilter<TInputImage>::VerifyPreconditions() ITKv5_CONST
 
   if (this->m_DesiredCoordinateOrientation == OrientationEnum::INVALID)
   {
-    itkExceptionMacro(<<"DesiredCoordinateOrientation is 'INVALID'.")
+    itkExceptionMacro(<<"DesiredCoordinateOrientation is 'INVALID'.");
   }
 }
 

--- a/include/itkNPasteImageFilter.hxx
+++ b/include/itkNPasteImageFilter.hxx
@@ -89,7 +89,7 @@ NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions(
 
   if (sourceInput == nullptr && constantInput == nullptr)
   {
-    itkExceptionMacro("The Source or the Constant input are required.")
+    itkExceptionMacro("The Source or the Constant input are required.");
   }
 
 
@@ -285,7 +285,7 @@ NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::GetPresumedDestinati
 
   if (numberSkippedAxis != (InputImageDimension - SourceImageDimension))
   {
-    itkExceptionMacro("Number of skipped axis " << m_DestinationSkipAxes)
+    itkExceptionMacro("Number of skipped axis " << m_DestinationSkipAxes);
   }
 
   InputImageSizeType ret;


### PR DESCRIPTION
A ';' is required at the end of macros in a future version of ITK. This will resolve build conflicts in source ITK. However,  this will likely break the CI for this module until the changes are released in a future version of ITK and the CI is updated with the new version.