### PR TITLE
COMP: Use modern macro for name of class

### DIFF
--- a/include/itkDICOMOrientImageFilter.h
+++ b/include/itkDICOMOrientImageFilter.h
@@ -96,7 +96,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(DICOMOrientImageFilter, ImageToImageFilter);
+   itkOverrideGetNameOfClassMacro(DICOMOrientImageFilter);
 
   using OrientationEnum = DICOMOrientation::OrientationEnum;
 

--- a/include/itkHessianImageFilter.h
+++ b/include/itkHessianImageFilter.h
@@ -66,7 +66,7 @@ public:
 
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(HessianImageFilter, ImageToImageFilter);
+   itkOverrideGetNameOfClassMacro(HessianImageFilter);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkMaskedAssignImageFilter.h
+++ b/include/itkMaskedAssignImageFilter.h
@@ -74,7 +74,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MaskedAssignImageFilter, TernaryGeneratorImageFilter);
+   itkOverrideGetNameOfClassMacro(MaskedAssignImageFilter);
 
   /** Typedefs **/
   using InputImageType = TInputImage;

--- a/include/itkNPasteImageFilter.h
+++ b/include/itkNPasteImageFilter.h
@@ -72,7 +72,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(NPasteImageFilter, InPlaceImageFilter);
+   itkOverrideGetNameOfClassMacro(NPasteImageFilter);
 
   /** Typedefs from Superclass */
   using InputImagePointer = typename Superclass::InputImagePointer;

--- a/include/itkObjectnessMeasureImageFilter.h
+++ b/include/itkObjectnessMeasureImageFilter.h
@@ -97,7 +97,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ObjectnessMeasureImageFilter, ImageToImageFilter);
+   itkOverrideGetNameOfClassMacro(ObjectnessMeasureImageFilter);
 
 
   /** Set/Get Alpha, the weight corresponding to R_A


### PR DESCRIPTION
When preparing for the future with ITK by setting
ITK_FUTURE_LEGACY_REMOVE:BOOL=ON
ITK_LEGACY_REMOVEBOOL=ON

The future preferred macro should be used
│ -  itkTypeMacro
│ +  itkOverrideGetNameOfClassMacro