### PR TITLE
Update tests for throwing exception with inputs

### DIFF
--- a/test/itkMaskedAssignImageFilterGTest.cxx
+++ b/test/itkMaskedAssignImageFilterGTest.cxx
@@ -136,7 +136,7 @@ TEST_F(MaskedAssignFixture, SetGetPrint)
   EXPECT_ANY_THROW(filter->GetConstant1());
 
   EXPECT_NO_THROW(filter->SetConstant1(1));
-  EXPECT_NO_THROW(filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetInput());
   EXPECT_EQ(1, filter->GetConstant1());
 
 
@@ -151,7 +151,7 @@ TEST_F(MaskedAssignFixture, SetGetPrint)
   EXPECT_ANY_THROW(filter->GetConstant2());
 
   EXPECT_NO_THROW(filter->SetConstant2(2));
-  EXPECT_NO_THROW(filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetMaskImage());
   EXPECT_EQ(2, filter->GetConstant2());
 
 
@@ -168,12 +168,12 @@ TEST_F(MaskedAssignFixture, SetGetPrint)
   EXPECT_ANY_THROW(filter->GetAssignConstant());
 
   EXPECT_NO_THROW(filter->SetConstant3(3));
-  EXPECT_NO_THROW(filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetMaskImage());
   EXPECT_EQ(3, filter->GetConstant3());
 
 
   EXPECT_NO_THROW(filter->SetAssignConstant(4));
-  EXPECT_NO_THROW(filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetMaskImage());
   EXPECT_EQ(4, filter->GetConstant3());
   EXPECT_EQ(4, filter->GetAssignConstant());
 }


### PR DESCRIPTION
Inputs slots can have multiple types, current behavior is to throw an exception when the getter does not match the current type. For example if a image is asked for when a constant is set.