### PR TITLE
ENH: ITKv5_CONST macro for VerifyPreconditions() and VerifyInputInformation()

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,319 @@
+## This config file is only relevant for clang-format version 19.1.7
+##
+## Examples of each format style can be found on the in the clang-format documentation
+## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
+##
+## The clang-format binaries can be downloaded as part of the clang binary distributions
+## from https://releases.llvm.org/download.html
+##
+## Use the script Utilities/Maintenance/clang-format.bash to faciliate
+## maintaining a consistent code style.
+##
+## EXAMPLE apply code style enforcement before commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.7} --modified
+## EXAMPLE apply code style enforcement after commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.7} --last
+---
+# This configuration requires clang-format version 19.1.7 exactly.
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: Inline Only merge functions defined inside a class. Implies empty.
+#AllowShortFunctionsOnASingleLine: None (in configuration: None) Never merge functions into a single line.
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: All
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+## The following line allows larger lines in non-documentation code
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+## The following line allows larger lines in non-documentation code
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+PPIndentWidth:   -1
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+# We may want to sort the includes as a separate pass
+SortIncludes:    Never
+SortJavaStaticImport: Before
+# We may want to revisit this later
+SortUsingDeclarations: Never
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - ITK_GCC_PRAGMA_PUSH
+  - ITK_GCC_PRAGMA_POP
+  - ITK_GCC_SUPPRESS_Wfloat_equal
+  - ITK_GCC_SUPPRESS_Wformat_nonliteral
+  - ITK_GCC_SUPPRESS_Warray_bounds
+  - ITK_CLANG_PRAGMA_PUSH
+  - ITK_CLANG_PRAGMA_POP
+  - ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+  - ITK_CLANG_SUPPRESS_Wduplicate_enum
+  - CLANG_PRAGMA_PUSH
+  - CLANG_PRAGMA_POP
+  - CLANG_SUPPRESS_Wfloat_equal
+  - INTEL_PRAGMA_WARN_PUSH
+  - INTEL_PRAGMA_WARN_POP
+  - INTEL_SUPPRESS_warning_1292
+  - itkTemplateFloatingToIntegerMacro
+  - itkLegacyMacro
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth:        2
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,6 +7,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-
-    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
+    - uses: actions/checkout@v5
+    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@main

--- a/include/itkDICOMOrientImageFilter.h
+++ b/include/itkDICOMOrientImageFilter.h
@@ -168,7 +168,7 @@ protected:
   SetInputCoordinateOrientation(OrientationEnum newCode);
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   /** Single-threaded version of GenerateData. This filter delegates
    * to PermuteAxesImageFilter and FlipImageFilter. */

--- a/include/itkDICOMOrientImageFilter.hxx
+++ b/include/itkDICOMOrientImageFilter.hxx
@@ -295,7 +295,7 @@ DICOMOrientImageFilter<TInputImage>::GenerateOutputInformation()
 
 template <typename TInputImage>
 void
-DICOMOrientImageFilter<TInputImage>::VerifyPreconditions() ITKv5_CONST
+DICOMOrientImageFilter<TInputImage>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/include/itkNPasteImageFilter.h
+++ b/include/itkNPasteImageFilter.h
@@ -170,11 +170,11 @@ public:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   bool
   CanRunInPlace() const override;

--- a/include/itkNPasteImageFilter.hxx
+++ b/include/itkNPasteImageFilter.hxx
@@ -79,7 +79,7 @@ NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::GenerateInputRequest
 
 template <typename TInputImage, typename TSourceImage, typename TOutputImage>
 void
-NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+NPasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/src/itkDICOMOrientation.cxx
+++ b/src/itkDICOMOrientation.cxx
@@ -170,19 +170,19 @@ DICOMOrientation::DirectionCosinesToOrientation(const DirectionType & dir)
   // but it is DIFFERENT in the meaning of direction in terms of sign-ness.
   CoordinateEnum terms[3] = { CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN };
 
-  std::multimap< double, std::pair<unsigned, unsigned> > value_to_idx;
-  for (unsigned int c = 0; c < 3; ++c )
+  std::multimap<double, std::pair<unsigned, unsigned>> value_to_idx;
+  for (unsigned int c = 0; c < 3; ++c)
+  {
+    for (unsigned int r = 0; r < 3; ++r)
     {
-    for (unsigned int r = 0; r < 3; ++r )
-      {
-      value_to_idx.emplace(std::abs(dir[c][r]), std::make_pair(c,r));
-      }
+      value_to_idx.emplace(std::abs(dir[c][r]), std::make_pair(c, r));
     }
+  }
 
   for (unsigned i = 0; i < 3; ++i)
-    {
+  {
 
-    auto max_idx = value_to_idx.rbegin()->second;
+    auto               max_idx = value_to_idx.rbegin()->second;
     const unsigned int max_c = max_idx.first;
     const unsigned int max_r = max_idx.second;
 
@@ -190,29 +190,32 @@ DICOMOrientation::DirectionCosinesToOrientation(const DirectionType & dir)
 
     for (auto it = value_to_idx.begin(); it != value_to_idx.end();)
     {
-    if (it->second.first == max_c || it->second.second == max_r)
+      if (it->second.first == max_c || it->second.second == max_r)
       {
-      value_to_idx.erase(it++);
+        value_to_idx.erase(it++);
       }
-    else
+      else
       {
-      ++it;
+        ++it;
       }
     }
 
     switch (max_c)
     {
-      case 0: {
+      case 0:
+      {
         // When the dominant axis sign is positive, assign the coordinate for the direction we are increasing towards.
         // ITK is in LPS, so that is the positive direction
         terms[max_r] = (max_sgn == 1) ? CoordinateEnum::Left : CoordinateEnum::Right;
         break;
       }
-      case 1: {
+      case 1:
+      {
         terms[max_r] = (max_sgn == 1) ? CoordinateEnum::Posterior : CoordinateEnum::Anterior;
         break;
       }
-      case 2: {
+      case 2:
+      {
         terms[max_r] = (max_sgn == 1) ? CoordinateEnum::Superior : CoordinateEnum::Inferior;
         break;
       }

--- a/test/itkDICOMOrientImageFilterGTest.cxx
+++ b/test/itkDICOMOrientImageFilterGTest.cxx
@@ -451,13 +451,12 @@ TEST(DICOMOrientation, DirectionCosinesToOrientation)
   d(0, 2) = 1;
   EXPECT_EQ(OE::SPL, DICOMOrientation::DirectionCosinesToOrientation(d));
 
-  const double data[] = {0.5986634407395047, 0.22716302314740483, -0.768113953548866,
-                         0.5627936241740271, 0.563067040943212, 0.6051601804419384,
-                         0.5699696670095713, -0.794576911518317, 0.20924175102261847};
-  ImageType::DirectionType::InternalMatrixType m{data};
+  const double                                 data[] = { 0.5986634407395047, 0.22716302314740483, -0.768113953548866,
+                                                          0.5627936241740271, 0.563067040943212,   0.6051601804419384,
+                                                          0.5699696670095713, -0.794576911518317,  0.20924175102261847 };
+  ImageType::DirectionType::InternalMatrixType m{ data };
   d.GetVnlMatrix() = m;
   EXPECT_EQ(OE::PIR, DICOMOrientation::DirectionCosinesToOrientation(d));
-
 }
 
 TEST(DICOMOrientation, OrientationToDirectionCosines)

--- a/test/itkHessianImageFilterGTest.cxx
+++ b/test/itkHessianImageFilterGTest.cxx
@@ -159,8 +159,9 @@ TEST_F(HessianImageFilterFixture, ValueTest_3D)
   std::cout << "Value: " << image->GetPixel(itk::MakeIndex(13, 12, 12)) << std::endl;
   std::cout << "Value: " << image->GetPixel(itk::MakeIndex(14, 12, 12)) << std::endl;
 
-  ITK_EXPECT_VECTOR_NEAR(
-    MakeFixedArray(-0.0001615, 0.0, 0.0, -0.0001615, 0.0, -0.0001615), output->GetPixel(itk::MakeIndex(12, 12, 12)), 1e-6);
+  ITK_EXPECT_VECTOR_NEAR(MakeFixedArray(-0.0001615, 0.0, 0.0, -0.0001615, 0.0, -0.0001615),
+                         output->GetPixel(itk::MakeIndex(12, 12, 12)),
+                         1e-6);
 
   ITK_EXPECT_VECTOR_NEAR(MakeFixedArray(-0.00014602, 0.0, 0.0, -0.00014602, 0.0, -0.00014602),
                          output->GetPixel(itk::MakeIndex(10, 10, 10)),


### PR DESCRIPTION
ITKv5_CONST enables backwards compatible behavior when ITKV4_COMPATIBILITY
is turned ON for methods which have acquired 'const' qualifier in ITKv5.
Breaking changes were originally introduced by ITK  commits
3e6b6f5bd6772316aa0fa6b89f31b42bef562112 (on 2018-10-18) and
16eae15c1bb6cc1bae9fba3e09a3102bdc02e955 (on 2018-10-23).
